### PR TITLE
resize: Make a target for standalone resize2fs_static binary

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,1 @@
+include $(call all-subdir-makefiles)

--- a/contrib/Android.mk
+++ b/contrib/Android.mk
@@ -1,0 +1,1 @@
+include $(call all-subdir-makefiles)

--- a/resize/Android.mk
+++ b/resize/Android.mk
@@ -1,0 +1,34 @@
+LOCAL_PATH := $(call my-dir)
+
+resize2fs_src_files := \
+	extent.c \
+	resize2fs.c \
+	main.c \
+	online.c \
+	sim_progress.c \
+	resource_track.c
+
+resize2fs_c_includes := external/e2fsprogs/lib
+
+resize2fs_cflags := -O2 -g -W -Wall
+
+resize2fs_shared_libraries := \
+	libext2fs \
+	libext2_com_err \
+	libext2_e2p \
+	libext2_uuid \
+	libext2_blkid
+
+resize2fs_system_shared_libraries := libc
+
+include $(CLEAR_VARS)
+LOCAL_SRC_FILES := $(resize2fs_src_files)
+LOCAL_C_INCLUDES := $(resize2fs_c_includes)
+LOCAL_CFLAGS := $(resize2fs_cflags)
+LOCAL_STATIC_LIBRARIES := $(resize2fs_shared_libraries)
+LOCAL_STATIC_LIBRARIES += $(resize2fs_system_shared_libraries)
+LOCAL_MODULE := resize2fs_static
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(PRODUCT_OUT)/install/bin
+LOCAL_FORCE_STATIC_EXECUTABLE := true
+include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
Author: Bruno Martins <bgcngm@gmail.com>
Date:   Tue Mar 20 00:28:54 2018 +0000

    resize: Make a target for standalone resize2fs_static binary

     * Some devices still ship this static binary into the OTA in order to
       automatically resize system partition after OTA is installed.

     * This restores resize/Android.mk that had been removed in commit 7a9e1a9
       and applies commit 0f37ade7. Apparently this is the only way to copy
       the executable to a path outside $OUT/system without messing with soong.

    Change-Id: Ied438c977d0920ef672dcce156ff62d5c658aa33

Author: Tom Marshall <tdm.code@gmail.com>
Date:   Fri Jan 18 09:41:18 2019 -0800

    e2fsprogs: Fix resize2fs_static build

    Change "resize: Make a target for standalone resize2fs_static binary"
    added a top level Android.mk which broke e2fsdroid_static because the
    macro all-sudbir-makefiles only looks one level deep.

    Fix this by adding an Android.mk to contrib, so that the build system
    sees contrib/android/Android.mk.

    Change-Id: I91e673dd207af3f6c7176370b3598a5eefd952b2

Change-Id: I62229325f0ee9efb65aa61c3f903f41ca7c978b8